### PR TITLE
ZFS repo paths now require the minor version number

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -3,13 +3,9 @@
   set_fact:
     clean_distribution_version: "{{ ansible_distribution_version | replace('.', '_') }}"
 
-- name: Convert Distribution Version to Shorthand (CentOS)
-  set_fact:
-    shorthand_distribution_version: "{{ clean_distribution_version | regex_replace('(_[0-9]+)$', '') }}"
-
 - name: Set ZFS on Linux Repo URL (CentOS)
   set_fact:
-    zfs_repo_url: "{{ zfs_repo_download_url }}/epel/{{ zfs_repo_release_name }}.el{{ shorthand_distribution_version }}.noarch.rpm"
+    zfs_repo_url: "{{ zfs_repo_download_url }}/epel/{{ zfs_repo_release_name }}.el{{ clean_distribution_version }}.noarch.rpm"
 
 - name: Install ZFS on Linux Repo (CentOS)
   become: true


### PR DESCRIPTION
The current ZFS on linux epel paths for Centos now need the major
and minor revision numbers. Therefore the shorthand of the version
is no longer needed.

	modified:   tasks/CentOS.yml